### PR TITLE
Add HPX tests

### DIFF
--- a/validation_tests/hpx/CMakeLists.txt
+++ b/validation_tests/hpx/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 3.17)
+project(test CXX)
+find_package(HPX 1.7.0 REQUIRED)
+
+add_executable(test_future test_future.cpp)
+target_link_libraries(test_future PRIVATE HPX::hpx)
+target_include_directories(test_future PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(test_algorithm test_algorithm.cpp)
+target_link_libraries(test_algorithm PRIVATE HPX::hpx)
+target_include_directories(test_algorithm PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_executable(test_distributed test_distributed.cpp)
+target_link_libraries(test_distributed PRIVATE HPX::hpx HPX::wrap_main
+                                               HPX::iostreams_component)
+
+if(HPX_WITH_CUDA)
+  enable_language(CUDA)
+  set_source_files_properties(test_gpu.cpp PROPERTIES LANGUAGE CUDA)
+endif()
+add_executable(test_gpu test_gpu.cpp)
+target_link_libraries(test_gpu PRIVATE HPX::hpx)
+target_include_directories(test_gpu PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+if(HPX_WITH_CUDA)
+  target_compile_options(test_gpu PRIVATE --expt-extended-lambda --expt-relaxed-constexpr)
+endif()

--- a/validation_tests/hpx/check_helper.hpp
+++ b/validation_tests/hpx/check_helper.hpp
@@ -1,0 +1,19 @@
+//  Copyright (c) 2021 Ste||ar Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <sstream>
+#include <stdexcept>
+#include <string>
+
+template <typename T, typename U>
+void check(std::string const &test_name, T &&expected, U &&result) {
+  if (result != expected) {
+    std::ostringstream s;
+    s << "HPX \"" << test_name << "\" test failed. Expected " << expected
+      << ", got " << result;
+    throw std::runtime_error(s.str());
+  }
+}

--- a/validation_tests/hpx/clean.sh
+++ b/validation_tests/hpx/clean.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+. ./setup.sh
+rm -rf ./build
+rm -rf ./*distributed*.log

--- a/validation_tests/hpx/compile.sh
+++ b/validation_tests/hpx/compile.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+. ./setup.sh
+spackLoadUnique cmake@3.17:
+set -x
+
+mkdir -p build
+cmake -B build -S .
+cmake --build build

--- a/validation_tests/hpx/run.sh
+++ b/validation_tests/hpx/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+. ./setup.sh
+set -x
+$TEST_RUN_CMD $TEST_RUN_PROCFLAG 1 ./build/test_future --hpx:use-process-mask
+$TEST_RUN_CMD $TEST_RUN_PROCFLAG 1 ./build/test_algorithm --hpx:use-process-mask
+$TEST_RUN_CMD $TEST_RUN_PROCFLAG 1 ./build/test_gpu --hpx:use-process-mask
+
+$TEST_RUN ./build/test_distributed --hpx:use-process-mask > test_distributed.log
+sort test_distributed.log > test_distributed_sorted.log
+rm -f test_distributed_reference.log
+for i in $(seq 0 $((TEST_RUN_PROCARG - 1))); do
+    echo "Hello world from locality $i" >> test_distributed_reference.log
+done
+diff test_distributed_sorted.log test_distributed_reference.log

--- a/validation_tests/hpx/setup.sh
+++ b/validation_tests/hpx/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+. ../../setup.sh
+spackLoadUnique hpx networking=mpi

--- a/validation_tests/hpx/test_algorithm.cpp
+++ b/validation_tests/hpx/test_algorithm.cpp
@@ -1,0 +1,43 @@
+//  Copyright (c) 2021 Ste||ar Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+#include <hpx/program_options.hpp>
+
+#include <check_helper.hpp>
+
+#include <cstdint>
+#include <vector>
+
+int hpx_main(hpx::program_options::variables_map &vm) {
+  // Smoke test for basic parallel algorithms functionality
+  std::uint64_t const n = vm["n"].as<std::uint64_t>();
+
+  std::vector<std::uint64_t> v(n);
+  hpx::for_loop(hpx::execution::par, 0, v.size(),
+                [&](std::size_t i) { v[i] = i; });
+  std::uint64_t const result = hpx::ranges::reduce(hpx::execution::par, v, 0,
+                                                   std::plus<std::uint64_t>{});
+
+  std::uint64_t const expected = n * (n - 1) / 2;
+  check("reduction", expected, result);
+
+  return hpx::finalize();
+}
+
+int main(int argc, char *argv[]) {
+  hpx::init_params p;
+  hpx::program_options::options_description opts(
+      "Usage: test_algorithm [options]");
+  opts.add_options()(
+      "n", hpx::program_options::value<std::uint64_t>()->default_value(10000),
+      "number of elements to use in reduction test");
+  p.desc_cmdline = opts;
+
+  return hpx::init(argc, argv, p);
+}

--- a/validation_tests/hpx/test_distributed.cpp
+++ b/validation_tests/hpx/test_distributed.cpp
@@ -1,0 +1,36 @@
+//  Copyright (c) 2021 Ste||ar Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/future.hpp>
+#include <hpx/include/actions.hpp>
+#include <hpx/iostream.hpp>
+#include <hpx/wrap_main.hpp>
+
+#include <ostream>
+#include <vector>
+
+void hello_world() {
+  hpx::cout << "Hello world from locality " << hpx::get_locality_id()
+            << std::endl;
+}
+
+HPX_PLAIN_ACTION(hello_world, hello_world_action);
+
+int main() {
+  std::vector<hpx::naming::id_type> localities = hpx::find_all_localities();
+  std::vector<hpx::lcos::future<void>> futures;
+  futures.reserve(localities.size());
+
+  for (hpx::naming::id_type const &locality : localities) {
+    futures.push_back(hpx::async<hello_world_action>(locality));
+  }
+
+  hpx::when_all(futures).get();
+  return 0;
+}
+#endif

--- a/validation_tests/hpx/test_future.cpp
+++ b/validation_tests/hpx/test_future.cpp
@@ -1,0 +1,47 @@
+//  Copyright (c) 2021 Ste||ar Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/execution.hpp>
+#include <hpx/future.hpp>
+#include <hpx/init.hpp>
+#include <hpx/program_options.hpp>
+#include <hpx/thread.hpp>
+
+#include <check_helper.hpp>
+
+#include <chrono>
+#include <cstdint>
+
+int hpx_main(hpx::program_options::variables_map &vm) {
+  // Smoke test for basic futures functionality
+  std::uint64_t const n = vm["n"].as<std::uint64_t>();
+
+  auto slow_function = [n]() {
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(500));
+    return 2 * n;
+  };
+  auto join_function = [](std::uint64_t x, std::uint64_t y) { return x + y; };
+  hpx::future<std::uint64_t> result_future =
+      hpx::dataflow(hpx::unwrapping(join_function), hpx::async(slow_function),
+                    hpx::make_ready_future(1));
+  std::uint64_t const result = result_future.get();
+
+  std::uint64_t const expected = 2 * n + 1;
+  check("future", expected, result);
+
+  return hpx::finalize();
+}
+
+int main(int argc, char *argv[]) {
+  hpx::init_params p;
+  hpx::program_options::options_description opts("Usage: test [options]");
+  opts.add_options()(
+      "n", hpx::program_options::value<std::uint64_t>()->default_value(42),
+      "input value for future test");
+  p.desc_cmdline = opts;
+
+  return hpx::init(argc, argv, p);
+}

--- a/validation_tests/hpx/test_gpu.cpp
+++ b/validation_tests/hpx/test_gpu.cpp
@@ -1,0 +1,63 @@
+//  Copyright (c) 2021 Ste||ar Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/config.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/include/compute.hpp>
+#include <hpx/init.hpp>
+
+#include <check_helper.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+#if defined(HPX_HAVE_CUDA) || defined(HPX_HAVE_HIP)
+int hpx_main(hpx::program_options::variables_map &vm) {
+  // Smoke test for basic CUDA/HIP functionality
+  std::uint64_t const n = vm["n"].as<std::uint64_t>();
+
+  hpx::cuda::experimental::target target;
+  hpx::cuda::experimental::allocator<std::uint64_t> alloc(target);
+  hpx::cuda::experimental::default_executor exec(target);
+
+  std::vector<std::uint64_t> A_host(n);
+  hpx::compute::vector<std::uint64_t, decltype(alloc)> A_device(n, alloc);
+
+  hpx::for_loop(hpx::execution::par, 0, n,
+                [&](std::uint64_t i) { A_host[i] = i; });
+  hpx::copy(hpx::execution::par, A_host.begin(), A_host.end(),
+            A_device.begin());
+  hpx::ranges::for_each(hpx::execution::par.on(exec), A_device,
+                        [] HPX_HOST_DEVICE(std::uint64_t & i) { i += 5; });
+  hpx::copy(hpx::execution::par, A_device.begin(), A_device.end(),
+            A_host.begin());
+  hpx::for_loop(hpx::execution::par, 0, n, [&](std::uint64_t i) {
+    std::ostringstream s;
+    s << "gpu (element " << i << "/" << n << ")";
+    check(s.str(), i + 5, A_host[i]);
+  });
+
+  return hpx::finalize();
+}
+
+int main(int argc, char *argv[]) {
+  hpx::init_params p;
+  hpx::program_options::options_description opts("Usage: test_gpu [options]");
+  opts.add_options()(
+      "n", hpx::program_options::value<std::uint64_t>()->default_value(10000),
+      "number of elements to use in GPU test");
+  p.desc_cmdline = opts;
+
+  return hpx::init(argc, argv, p);
+}
+#else
+int main() {
+  std::cerr << "skipping HPX GPU test, CUDA/HIP support not available\n";
+}
+#endif


### PR DESCRIPTION
This adds tests for HPX: two plain CPU-only single-node smoke tests, one GPU test for CUDA and HIP, and one distributed test.

I was able to run these successfully locally, but is there any way to check that this is going to succeed on whatever system it will be run on? I currently require nothing special from the hpx spec, and e.g. the GPU test compiles to an empty test if HPX doesn't have `+cuda` or `+rocm` in the spec. The distributed test should run with with any parcelport (the `networking` variant), assuming it's launched appropriately. `networking=none` would not work. Can I assume that the spec will always not be `networking=none` (`tcp` is the default)?

Ping @hkaiser.