### PR TITLE
Add validation test for visit.

### DIFF
--- a/validation_tests/visit/clean.sh
+++ b/validation_tests/visit/clean.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+rm -f visitlog.py visit*.png

--- a/validation_tests/visit/run.sh
+++ b/validation_tests/visit/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+. ./setup.sh
+set -x
+${VISIT_ROOT}/bin/visit -cli -nowin -s test1.py

--- a/validation_tests/visit/setup.sh
+++ b/validation_tests/visit/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+. ../../setup.sh
+spackLoadUnique visit

--- a/validation_tests/visit/test1.py
+++ b/validation_tests/visit/test1.py
@@ -1,0 +1,25 @@
+import os
+
+VISIT_ROOT = os.getenv('VISIT_ROOT')
+
+# Turn off some annotations
+annot=AnnotationAttributes()
+annot.userInfoFlag=0
+SetAnnotationAttributes(annot)
+
+# Open a database and create a plot
+OpenDatabase("%s/data/curv2d.silo" % VISIT_ROOT)
+AddPlot("Pseudocolor", "d")
+DrawPlots()
+
+# Save the image
+swa = SaveWindowAttributes()
+swa.family = 0
+swa.fileName = "visit0000"
+swa.resConstraint = swa.NoConstraint
+swa.width = 600
+swa.height = 400
+SetSaveWindowAttributes(swa)
+SaveWindow()
+
+quit()


### PR DESCRIPTION
Added a validation test for VisIt.

The test uses the VisIt python scripting interface to open one of the files that is part of the VisIt distribution and creates a pseudocolor plot and saves the resulting image in a png file.

This tests that VisIt is able to open a file, create an image and save the result to a png file. No check is currently performed to make sure that the image is correct.

This was tested on spock and I verified that the image created is correct.