### PR TITLE
libcatalyst: add simple validation test

### DIFF
--- a/validation_tests/libcatalyst/build/.gitignore
+++ b/validation_tests/libcatalyst/build/.gitignore
@@ -1,0 +1,2 @@
+# libcatalyst builds happen under here.
+libcatalyst-examples/

--- a/validation_tests/libcatalyst/clean.sh
+++ b/validation_tests/libcatalyst/clean.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+. ./setup.sh
+
+# Remove the examples resources.
+rm -rf build/libcatalyst-examples/

--- a/validation_tests/libcatalyst/compile.sh
+++ b/validation_tests/libcatalyst/compile.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+#----------------------------------------
+# Variables for use later
+#----------------------------------------
+readonly workdir="build"
+
+#----------------------------------------
+# Catalyst upstream examples
+#----------------------------------------
+
+# First clone catalyst and run its examples.
+mkdir -p "$workdir/libcatalyst-examples" # Must be removed in `clean.sh`
+pushd "$workdir/libcatalyst-examples"
+git clone https://gitlab.kitware.com/paraview/catalyst.git src
+
+catalyst_examples_src="$( pwd )/src"
+readonly catalyst_examples_src
+
+readonly catalyst_examples_args=(
+    "-DCMAKE_PREFIX_PATH=$catalyst_ROOT"
+    -DCATALYST_BUILD_REPLAY=ON
+    -DBUILD_SHARED_LIBS=ON
+    "$catalyst_examples_src/examples"
+)
+
+# Build with Ninja
+mkdir build-ninja
+pushd build-ninja
+cmake -G Ninja "${catalyst_examples_args[@]}"
+cmake --build .
+popd
+
+# Build with Makefiles
+mkdir build-make
+pushd build-make
+cmake -G "Unix Makefiles" "${catalyst_examples_args[@]}"
+cmake --build .
+popd
+popd

--- a/validation_tests/libcatalyst/run.sh
+++ b/validation_tests/libcatalyst/run.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -e
+
+#----------------------------------------
+# Variables for use later
+#----------------------------------------
+readonly workdir="build"
+
+#----------------------------------------
+# Catalyst upstream examples
+#----------------------------------------
+ctest --output-on-failure --test-dir "$workdir/libcatalyst-examples/build-ninja"
+ctest --output-on-failure --test-dir "$workdir/libcatalyst-examples/build-make"

--- a/validation_tests/libcatalyst/setup.sh
+++ b/validation_tests/libcatalyst/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+. ../../setup.sh
+
+# Actually testing `libcatalyst`
+spackLoadUnique libcatalyst@2.0.0-rc3:
+
+# Also need `cmake`, and `ninja` to build tests.
+spackLoadUnique cmake
+spackLoadUnique ninja


### PR DESCRIPTION
This test uses catalyst's own in-repo examples as a smoke test.

---
Note that this requires catalyst 2.0.0-rc3 or higher (I'll be filing a Spack PR for that once I tag upstream).