### PR TITLE
test-all: use a sortable date format

### DIFF
--- a/test-all.sh
+++ b/test-all.sh
@@ -7,7 +7,7 @@ print_logs=false
 basedir=validation_tests
 export e4s_print_color=true
 skip_to=""
-testtime=$(date +"%m-%d-%y_%T")
+testtime=$(date +"%Y-%m-%d_%T")
 
     if [[ $# -gt 0 && -d $1 ]] ; then
        basedir=$1


### PR DESCRIPTION
The American date format is an abomination and should not be used for filenames so that sorting can work. -- An American