### PR TITLE
hpctoolkit: Fix job launcher support, and use newer hpcstruct form

### DIFF
--- a/validation_tests/hpctoolkit/loop/Makefile
+++ b/validation_tests/hpctoolkit/loop/Makefile
@@ -5,9 +5,9 @@ loop: loop.c
 	$(CC) -o $@ $<
 
 run:
-	hpcrun -e REALTIME ./loop 10000000000
-	hpcstruct loop
-	hpcprof -S loop.hpcstruct hpctoolkit-loop-measurements
+	hpcrun -o hpctoolkit-loop-measurements -e REALTIME ./loop 10000000000
+	hpcstruct --nocache hpctoolkit-loop-measurements
+	hpcprof -o hpctoolkit-loop-database hpctoolkit-loop-measurements
 
 clean:
 	rm -f loop


### PR DESCRIPTION
Fixes [a recently identified flaw when running under a job launcher](https://github.com/buildtesters/buildtest-nersc/issues/141), and also upgrades the test to use our newer `hpctoolkit <measurements dir>` command form.

Ping @scottkwarren @wyphan