### PR TITLE
add Chapel validation tests

### DIFF
--- a/validation_tests/chapel/clean.sh
+++ b/validation_tests/chapel/clean.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo "Internal Spack test. No clean step required."

--- a/validation_tests/chapel/compile.sh
+++ b/validation_tests/chapel/compile.sh
@@ -1,0 +1,2 @@
+#!/bin/bash -e
+echo "Internal Spack test. No build step required."

--- a/validation_tests/chapel/run.sh
+++ b/validation_tests/chapel/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+. ./setup.sh
+set -x
+spackTestRun $CHAPEL_HASH

--- a/validation_tests/chapel/setup.sh
+++ b/validation_tests/chapel/setup.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+. ../../setup.sh  #The top level
+spackLoadUnique chapel


### PR DESCRIPTION
This adds validation tests for the Chapel language spack package. The files are based off examples in the `templates/spack-internal-test` directory. This test has been checked on perlmutter and a local linux system with spack installs of Chapel using `./test-all.sh ./validation_tests/chapel`